### PR TITLE
fix: Table-based query layer, enable GitHub Pages, add UI improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FractalMind Explorer</title>
   </head>
-  <body class="bg-gray-950 text-gray-100">
+  <body class="bg-base text-primary">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
 import { useState, useCallback } from "react";
 import { useSuiData } from "./hooks/useSuiData.ts";
+import { useTheme } from "./hooks/useTheme.ts";
 import ForceGraph from "./components/ForceGraph.tsx";
 import DetailPanel, { type DetailItem } from "./components/DetailPanel.tsx";
 import TaskFlow from "./components/TaskFlow.tsx";
 import PeerList from "./components/PeerList.tsx";
+import ErrorRetry from "./components/ErrorRetry.tsx";
+import { SidebarSkeleton, GraphSkeleton } from "./components/Skeleton.tsx";
 import { NODE_COLORS, truncateId } from "./components/utils.ts";
 import { SUI_CONFIG, suiScanUrl } from "./sui/config.ts";
 import type { GraphNode } from "./sui/types.ts";
@@ -18,6 +21,7 @@ const VIEWS: { key: View; label: string; icon: string }[] = [
 
 export default function App() {
   const data = useSuiData();
+  const { theme, toggle: toggleTheme } = useTheme();
   const [activeView, setActiveView] = useState<View>("org");
   const [selectedNode, setSelectedNode] = useState<DetailItem | null>(null);
 
@@ -31,31 +35,35 @@ export default function App() {
     data.organizations.length +
     data.agents.length +
     data.tasks.length +
-    data.fractals.length +
     data.peers.length;
 
+  const isFirstLoad = data.loading && totalObjects === 0;
+
+  const rootOrgs = data.organizations.filter((o) => o.depth === 0);
+  const subOrgs = data.organizations.filter((o) => o.depth > 0);
+
   return (
-    <div className="min-h-screen bg-gray-950 flex flex-col">
+    <div className="min-h-screen bg-base flex flex-col">
       {/* Header */}
-      <header className="border-b border-gray-800 bg-gray-950/80 backdrop-blur-sm sticky top-0 z-40">
+      <header className="border-b border-border bg-base/80 backdrop-blur-sm sticky top-0 z-40">
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-fractal-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm">
               FM
             </div>
             <div>
-              <h1 className="text-lg font-bold text-white leading-tight">
+              <h1 className="text-lg font-bold text-primary leading-tight">
                 FractalMind Explorer
               </h1>
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-muted">
                 On-chain AI Organization Visualizer — SUI Testnet
               </p>
             </div>
           </div>
 
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
             {/* Stats */}
-            <div className="hidden sm:flex items-center gap-3 text-xs text-gray-500">
+            <div className="hidden sm:flex items-center gap-3 text-xs text-muted mr-1">
               {data.loading && (
                 <span className="flex items-center gap-1.5">
                   <span className="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse-dot" />
@@ -68,7 +76,7 @@ export default function App() {
                   {totalObjects} objects
                 </span>
               )}
-              {data.error && (
+              {data.error && !data.loading && (
                 <span className="flex items-center gap-1.5 text-red-400">
                   <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
                   Error
@@ -76,11 +84,28 @@ export default function App() {
               )}
             </div>
 
+            {/* Theme toggle */}
+            <button
+              onClick={toggleTheme}
+              className="p-2 rounded-lg hover:bg-hover text-secondary hover:text-primary transition-colors cursor-pointer"
+              title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+            >
+              {theme === "dark" ? (
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                </svg>
+              )}
+            </button>
+
             {/* Refresh */}
             <button
               onClick={data.refresh}
               disabled={data.loading}
-              className="p-2 rounded-lg hover:bg-gray-800 text-gray-400 hover:text-white transition-colors disabled:opacity-50 cursor-pointer"
+              className="p-2 rounded-lg hover:bg-hover text-secondary hover:text-primary transition-colors disabled:opacity-50 cursor-pointer"
               title="Refresh data"
             >
               <svg
@@ -103,7 +128,7 @@ export default function App() {
               href={suiScanUrl("object", SUI_CONFIG.registry)}
               target="_blank"
               rel="noopener noreferrer"
-              className="p-2 rounded-lg hover:bg-gray-800 text-gray-400 hover:text-white transition-colors"
+              className="p-2 rounded-lg hover:bg-hover text-secondary hover:text-primary transition-colors"
               title="View Registry on SuiScan"
             >
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -123,143 +148,131 @@ export default function App() {
       <main className="flex-1 flex flex-col lg:flex-row max-w-7xl mx-auto w-full px-4 py-4 gap-4">
         {/* Sidebar */}
         <aside className="w-full lg:w-72 shrink-0 space-y-4">
-          {/* View switcher */}
-          <div className="bg-gray-900/50 rounded-xl border border-gray-800 p-2">
-            {VIEWS.map((v) => (
-              <button
-                key={v.key}
-                onClick={() => {
-                  setActiveView(v.key);
-                  setSelectedNode(null);
-                }}
-                className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-                  activeView === v.key
-                    ? "bg-fractal-600/20 text-fractal-300 border border-fractal-600/30"
-                    : "text-gray-400 hover:text-gray-200 hover:bg-gray-800/50 border border-transparent"
-                }`}
-              >
-                <span className="text-base">{v.icon}</span>
-                {v.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Legend */}
-          <div className="bg-gray-900/50 rounded-xl border border-gray-800 p-4">
-            <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
-              Legend
-            </h3>
-            <div className="space-y-1.5">
-              {Object.entries(NODE_COLORS).map(([type, color]) => (
-                <div key={type} className="flex items-center gap-2">
-                  <div
-                    className="w-3 h-3 rounded-full"
-                    style={{ backgroundColor: color }}
-                  />
-                  <span className="text-xs text-gray-400 capitalize">
-                    {type}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Object counts */}
-          <div className="bg-gray-900/50 rounded-xl border border-gray-800 p-4">
-            <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
-              On-chain Objects
-            </h3>
-            <div className="grid grid-cols-2 gap-2">
-              {[
-                { label: "Orgs", count: data.organizations.length, color: NODE_COLORS.org },
-                { label: "Agents", count: data.agents.length, color: NODE_COLORS.agent },
-                { label: "Tasks", count: data.tasks.length, color: NODE_COLORS.task },
-                { label: "Fractals", count: data.fractals.length, color: NODE_COLORS.fractal },
-                { label: "Peers", count: data.peers.length, color: NODE_COLORS.peer },
-              ].map((item) => (
-                <div
-                  key={item.label}
-                  className="bg-gray-800/50 rounded-lg p-2 text-center"
-                >
-                  <div
-                    className="text-lg font-bold"
-                    style={{ color: item.color }}
+          {isFirstLoad ? (
+            <SidebarSkeleton />
+          ) : (
+            <>
+              {/* View switcher */}
+              <div className="bg-surface-alt rounded-xl border border-border p-2">
+                {VIEWS.map((v) => (
+                  <button
+                    key={v.key}
+                    onClick={() => {
+                      setActiveView(v.key);
+                      setSelectedNode(null);
+                    }}
+                    className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+                      activeView === v.key
+                        ? "bg-fractal-600/20 text-fractal-300 border border-fractal-600/30"
+                        : "text-secondary hover:text-primary hover:bg-hover border border-transparent"
+                    }`}
                   >
-                    {item.count}
-                  </div>
-                  <div className="text-[10px] text-gray-500">{item.label}</div>
-                </div>
-              ))}
-            </div>
-          </div>
+                    <span className="text-base">{v.icon}</span>
+                    {v.label}
+                  </button>
+                ))}
+              </div>
 
-          {/* Info */}
-          <div className="bg-gray-900/50 rounded-xl border border-gray-800 p-4">
-            <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
-              Network
-            </h3>
-            <div className="space-y-1 text-xs text-gray-500">
-              <div>
-                Chain: <span className="text-gray-300">SUI Testnet</span>
+              {/* Legend */}
+              <div className="bg-surface-alt rounded-xl border border-border p-4">
+                <h3 className="text-xs font-medium text-muted uppercase tracking-wider mb-2">
+                  Legend
+                </h3>
+                <div className="space-y-1.5">
+                  {Object.entries(NODE_COLORS).map(([type, color]) => (
+                    <div key={type} className="flex items-center gap-2">
+                      <div
+                        className="w-3 h-3 rounded-full"
+                        style={{ backgroundColor: color }}
+                      />
+                      <span className="text-xs text-secondary capitalize">
+                        {type === "suborg" ? "Sub-Org" : type}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <div>
-                Package:{" "}
-                <a
-                  href={suiScanUrl("object", SUI_CONFIG.protocolPackage)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-fractal-400 hover:text-fractal-300 font-mono"
-                >
-                  {truncateId(SUI_CONFIG.protocolPackage, 4)}
-                </a>
+
+              {/* Object counts */}
+              <div className="bg-surface-alt rounded-xl border border-border p-4">
+                <h3 className="text-xs font-medium text-muted uppercase tracking-wider mb-2">
+                  On-chain Objects
+                </h3>
+                <div className="grid grid-cols-2 gap-2">
+                  {[
+                    { label: "Orgs", count: rootOrgs.length, color: NODE_COLORS.org },
+                    { label: "Sub-Orgs", count: subOrgs.length, color: NODE_COLORS.suborg },
+                    { label: "Agents", count: data.agents.length, color: NODE_COLORS.agent },
+                    { label: "Tasks", count: data.tasks.length, color: NODE_COLORS.task },
+                    { label: "Peers", count: data.peers.length, color: NODE_COLORS.peer },
+                  ].map((item) => (
+                    <div
+                      key={item.label}
+                      className="bg-hover rounded-lg p-2 text-center"
+                    >
+                      <div
+                        className="text-lg font-bold"
+                        style={{ color: item.color }}
+                      >
+                        {item.count}
+                      </div>
+                      <div className="text-[10px] text-muted">{item.label}</div>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <div>
-                Registry:{" "}
-                <a
-                  href={suiScanUrl("object", SUI_CONFIG.registry)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-fractal-400 hover:text-fractal-300 font-mono"
-                >
-                  {truncateId(SUI_CONFIG.registry, 4)}
-                </a>
+
+              {/* Network info */}
+              <div className="bg-surface-alt rounded-xl border border-border p-4">
+                <h3 className="text-xs font-medium text-muted uppercase tracking-wider mb-2">
+                  Network
+                </h3>
+                <div className="space-y-1 text-xs text-muted">
+                  <div>
+                    Chain: <span className="text-primary">SUI Testnet</span>
+                  </div>
+                  <div>
+                    Package:{" "}
+                    <a
+                      href={suiScanUrl("object", SUI_CONFIG.protocolPackage)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-fractal-400 hover:text-fractal-300 font-mono"
+                    >
+                      {truncateId(SUI_CONFIG.protocolPackage, 4)}
+                    </a>
+                  </div>
+                  <div>
+                    Registry:{" "}
+                    <a
+                      href={suiScanUrl("object", SUI_CONFIG.registry)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-fractal-400 hover:text-fractal-300 font-mono"
+                    >
+                      {truncateId(SUI_CONFIG.registry, 4)}
+                    </a>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+            </>
+          )}
         </aside>
 
         {/* Graph + detail area */}
         <div className="flex-1 flex flex-col gap-4 min-h-0">
           {/* Error banner */}
-          {data.error && (
-            <div className="bg-red-900/20 border border-red-800/50 rounded-xl px-4 py-3 text-sm text-red-300">
-              Failed to load data: {data.error}
-              <button
-                onClick={data.refresh}
-                className="ml-2 underline hover:no-underline cursor-pointer"
-              >
-                Retry
-              </button>
-            </div>
+          {data.error && !data.loading && (
+            <ErrorRetry error={data.error} onRetry={data.refresh} />
           )}
 
           {/* Force graph */}
-          <div className="flex-1 bg-gray-900/30 rounded-xl border border-gray-800 overflow-hidden relative min-h-[400px]">
-            {data.loading && totalObjects === 0 && (
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="text-center">
-                  <div className="w-8 h-8 border-2 border-fractal-500 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
-                  <div className="text-sm text-gray-500">
-                    Loading on-chain data...
-                  </div>
-                </div>
-              </div>
-            )}
+          <div className="flex-1 bg-surface-alt rounded-xl border border-border overflow-hidden relative min-h-[400px]">
+            {isFirstLoad && <GraphSkeleton />}
             <ForceGraph
               organizations={data.organizations}
               agents={data.agents}
               tasks={data.tasks}
-              fractals={data.fractals}
               peers={data.peers}
               activeView={activeView}
               onNodeClick={handleNodeClick}
@@ -267,13 +280,13 @@ export default function App() {
           </div>
 
           {/* Bottom panel for task/peer lists */}
-          {activeView === "tasks" && (
-            <div className="bg-gray-900/30 rounded-xl border border-gray-800 p-4 max-h-64 overflow-y-auto">
+          {activeView === "tasks" && !isFirstLoad && (
+            <div className="bg-surface-alt rounded-xl border border-border p-4 max-h-64 overflow-y-auto">
               <TaskFlow tasks={data.tasks} />
             </div>
           )}
-          {activeView === "peers" && (
-            <div className="bg-gray-900/30 rounded-xl border border-gray-800 p-4 max-h-64 overflow-y-auto">
+          {activeView === "peers" && !isFirstLoad && (
+            <div className="bg-surface-alt rounded-xl border border-border p-4 max-h-64 overflow-y-auto">
               <PeerList peers={data.peers} />
             </div>
           )}
@@ -284,7 +297,7 @@ export default function App() {
       <DetailPanel item={selectedNode} onClose={handleClose} />
 
       {/* Footer */}
-      <footer className="border-t border-gray-800 py-3 text-center text-xs text-gray-600">
+      <footer className="border-t border-border py-3 text-center text-xs text-muted">
         FractalMind Explorer — Built with React + D3.js + SUI SDK — Data from{" "}
         <a
           href="https://suiscan.xyz/testnet"

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -1,15 +1,14 @@
 import { truncateId, openOnSuiScan, STATUS_COLORS } from "./utils.ts";
 import type {
   Organization,
-  Agent,
+  AgentCertificate,
   Task,
-  Fractal,
   PeerNode,
 } from "../sui/types.ts";
 
 export interface DetailItem {
-  type: "org" | "agent" | "task" | "fractal" | "peer";
-  data: Organization | Agent | Task | Fractal | PeerNode;
+  type: "org" | "suborg" | "agent" | "task" | "peer";
+  data: Organization | AgentCertificate | Task | PeerNode;
 }
 
 interface Props {
@@ -35,10 +34,10 @@ function Badge({ label, color }: { label: string; color?: string }) {
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="mb-3">
-      <div className="text-xs text-gray-500 uppercase tracking-wider mb-0.5">
+      <div className="text-xs text-muted uppercase tracking-wider mb-0.5">
         {label}
       </div>
-      <div className="text-sm text-gray-200">{value}</div>
+      <div className="text-sm text-primary">{value}</div>
     </div>
   );
 }
@@ -60,6 +59,8 @@ function getDisplayName(item: DetailItem): string {
   if (typeof d.name === "string" && d.name) return d.name;
   if (typeof d.title === "string" && d.title) return d.title;
   if (typeof d.node_id === "string" && d.node_id) return d.node_id;
+  if (typeof d.agent === "string" && d.agent)
+    return truncateId(d.agent as string, 4);
   return truncateId(String(d.id ?? ""));
 }
 
@@ -67,35 +68,49 @@ export default function DetailPanel({ item, onClose }: Props) {
   if (!item) return null;
 
   return (
-    <div className="fixed right-0 top-0 h-full w-96 bg-gray-900/95 backdrop-blur-sm border-l border-gray-800 shadow-2xl z-50 overflow-y-auto animate-flow-in">
-      {/* Header */}
-      <div className="sticky top-0 bg-gray-900/90 backdrop-blur-sm border-b border-gray-800 px-5 py-4 flex items-center justify-between">
+    <div className="fixed right-0 top-0 h-full w-96 bg-surface/95 backdrop-blur-sm border-l border-border shadow-2xl z-50 overflow-y-auto animate-flow-in">
+      <div className="sticky top-0 bg-surface/90 backdrop-blur-sm border-b border-border px-5 py-4 flex items-center justify-between">
         <div>
-          <div className="text-xs text-gray-500 uppercase tracking-wider">
-            {item.type}
+          <div className="text-xs text-muted uppercase tracking-wider">
+            {item.type === "suborg" ? "Sub-Organization" : item.type}
           </div>
-          <h2 className="text-lg font-semibold text-white mt-0.5">
+          <h2 className="text-lg font-semibold text-primary mt-0.5">
             {getDisplayName(item)}
           </h2>
         </div>
         <button
           onClick={onClose}
-          className="p-1.5 rounded-lg hover:bg-gray-800 text-gray-400 hover:text-white transition-colors cursor-pointer"
+          className="p-1.5 rounded-lg hover:bg-hover text-secondary hover:text-primary transition-colors cursor-pointer"
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
           </svg>
         </button>
       </div>
 
-      {/* Body */}
       <div className="px-5 py-4">
-        <Field label="Object ID" value={<IdLink id={(item.data as { id: string }).id} />} />
+        <Field
+          label="Object ID"
+          value={<IdLink id={(item.data as { id: string }).id} />}
+        />
 
-        {item.type === "org" && <OrgDetail org={item.data as Organization} />}
-        {item.type === "agent" && <AgentDetail agent={item.data as Agent} />}
+        {(item.type === "org" || item.type === "suborg") && (
+          <OrgDetail org={item.data as Organization} />
+        )}
+        {item.type === "agent" && (
+          <AgentDetail agent={item.data as AgentCertificate} />
+        )}
         {item.type === "task" && <TaskDetail task={item.data as Task} />}
-        {item.type === "fractal" && <FractalDetail fractal={item.data as Fractal} />}
         {item.type === "peer" && <PeerDetail peer={item.data as PeerNode} />}
       </div>
     </div>
@@ -106,43 +121,73 @@ function OrgDetail({ org }: { org: Organization }) {
   return (
     <>
       <Field label="Description" value={org.description || "—"} />
+      <Field label="Depth" value={String(org.depth)} />
+      <Field
+        label="Active"
+        value={
+          <Badge
+            label={org.is_active ? "Yes" : "No"}
+            color={org.is_active ? "#20c997" : "#ff6b6b"}
+          />
+        }
+      />
       <Field label="Admin" value={<IdLink id={org.admin} />} />
+      {org.parent_org && (
+        <Field label="Parent Org" value={<IdLink id={org.parent_org} />} />
+      )}
       <Field
-        label="Agents"
+        label={`Agents (${org.agent_count})`}
         value={
-          org.agents.length > 0
-            ? org.agents.map((a) => <IdLink key={a} id={a} />)
-            : "None"
+          org.agent_addresses.length > 0 ? (
+            <div className="flex flex-wrap gap-1 mt-1">
+              {org.agent_addresses.map((a) => (
+                <IdLink key={a} id={a} />
+              ))}
+            </div>
+          ) : (
+            "None"
+          )
         }
       />
       <Field
-        label="Fractals"
+        label={`Child Orgs (${org.child_org_count})`}
         value={
-          org.fractals.length > 0
-            ? org.fractals.map((f) => <IdLink key={f} id={f} />)
-            : "None"
+          org.child_org_ids.length > 0 ? (
+            <div className="flex flex-wrap gap-1 mt-1">
+              {org.child_org_ids.map((id) => (
+                <IdLink key={id} id={id} />
+              ))}
+            </div>
+          ) : (
+            "None"
+          )
         }
       />
-      <Field label="Tasks" value={`${org.tasks.length} task(s)`} />
+      <Field label="Tasks" value={`${org.task_count} task(s)`} />
     </>
   );
 }
 
-function AgentDetail({ agent }: { agent: Agent }) {
+function AgentDetail({ agent }: { agent: AgentCertificate }) {
   return (
     <>
-      <Field label="Role" value={agent.role || "—"} />
+      <Field label="Agent Address" value={<IdLink id={agent.agent} />} />
       <Field
         label="Status"
-        value={<Badge label={agent.status} color={STATUS_COLORS[agent.status]} />}
+        value={
+          <Badge
+            label={agent.status}
+            color={STATUS_COLORS[agent.status]}
+          />
+        }
       />
       <Field label="Organization" value={<IdLink id={agent.org_id} />} />
       <Field
         label="Capabilities"
         value={
-          agent.capabilities.length > 0 ? (
+          agent.capability_tags.length > 0 ? (
             <div className="flex flex-wrap gap-1 mt-1">
-              {agent.capabilities.map((c, i) => (
+              {agent.capability_tags.map((c, i) => (
                 <Badge key={i} label={c} />
               ))}
             </div>
@@ -152,8 +197,12 @@ function AgentDetail({ agent }: { agent: Agent }) {
         }
       />
       <Field
-        label="Assigned Tasks"
-        value={`${agent.tasks_assigned.length} task(s)`}
+        label="Reputation Score"
+        value={String(agent.reputation_score)}
+      />
+      <Field
+        label="Tasks Completed"
+        value={String(agent.tasks_completed)}
       />
     </>
   );
@@ -174,12 +223,16 @@ function TaskDetail({ task }: { task: Task }) {
       <Field label="Description" value={task.description || "—"} />
       <Field
         label="Status"
-        value={<Badge label={task.status} color={STATUS_COLORS[task.status]} />}
+        value={
+          <Badge
+            label={task.status}
+            color={STATUS_COLORS[task.status]}
+          />
+        }
       />
 
-      {/* Task lifecycle flow */}
       <div className="my-4">
-        <div className="text-xs text-gray-500 uppercase tracking-wider mb-2">
+        <div className="text-xs text-muted uppercase tracking-wider mb-2">
           Lifecycle
         </div>
         <div className="flex items-center gap-1">
@@ -212,7 +265,7 @@ function TaskDetail({ task }: { task: Task }) {
         </div>
         <div className="flex justify-between mt-1 px-0.5">
           {steps.map((step) => (
-            <span key={step.key} className="text-[10px] text-gray-600">
+            <span key={step.key} className="text-[10px] text-muted">
               {step.label}
             </span>
           ))}
@@ -224,32 +277,13 @@ function TaskDetail({ task }: { task: Task }) {
         label="Assignee"
         value={task.assignee ? <IdLink id={task.assignee} /> : "Unassigned"}
       />
+      {task.verifier && (
+        <Field label="Verifier" value={<IdLink id={task.verifier} />} />
+      )}
+      {task.submission && (
+        <Field label="Submission" value={task.submission} />
+      )}
       <Field label="Organization" value={<IdLink id={task.org_id} />} />
-    </>
-  );
-}
-
-function FractalDetail({ fractal }: { fractal: Fractal }) {
-  return (
-    <>
-      <Field label="Depth" value={String(fractal.depth)} />
-      <Field label="Parent Org" value={<IdLink id={fractal.parent_org} />} />
-      <Field
-        label="Agents"
-        value={
-          fractal.agents.length > 0
-            ? fractal.agents.map((a) => <IdLink key={a} id={a} />)
-            : "None"
-        }
-      />
-      <Field
-        label="Sub-Fractals"
-        value={
-          fractal.sub_fractals.length > 0
-            ? fractal.sub_fractals.map((f) => <IdLink key={f} id={f} />)
-            : "None"
-        }
-      />
     </>
   );
 }
@@ -261,12 +295,14 @@ function PeerDetail({ peer }: { peer: PeerNode }) {
       <Field label="Endpoint" value={peer.endpoint || "—"} />
       <Field
         label="Status"
-        value={<Badge label={peer.status} color={STATUS_COLORS[peer.status]} />}
+        value={
+          <Badge
+            label={peer.status}
+            color={STATUS_COLORS[peer.status]}
+          />
+        }
       />
-      <Field
-        label="Last Heartbeat"
-        value={peer.last_heartbeat || "—"}
-      />
+      <Field label="Last Heartbeat" value={peer.last_heartbeat || "—"} />
       <Field
         label="Capabilities"
         value={

--- a/src/components/ErrorRetry.tsx
+++ b/src/components/ErrorRetry.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface Props {
+  error: string;
+  onRetry: () => void;
+}
+
+export default function ErrorRetry({ error, onRetry }: Props) {
+  const [countdown, setCountdown] = useState(15);
+  const [paused, setPaused] = useState(false);
+
+  const handleRetry = useCallback(() => {
+    setCountdown(15);
+    onRetry();
+  }, [onRetry]);
+
+  useEffect(() => {
+    if (paused) return;
+    if (countdown <= 0) {
+      handleRetry();
+      return;
+    }
+    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [countdown, paused, handleRetry]);
+
+  // Reset countdown when error changes
+  useEffect(() => {
+    setCountdown(15);
+    setPaused(false);
+  }, [error]);
+
+  return (
+    <div className="bg-red-500/10 border border-red-500/30 rounded-xl px-5 py-4">
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 mt-0.5">
+          <svg
+            className="w-5 h-5 text-red-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+            />
+          </svg>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-red-300">
+            Failed to load on-chain data
+          </div>
+          <div className="text-xs text-red-400/70 mt-1 break-words">
+            {error}
+          </div>
+          <div className="flex items-center gap-3 mt-3">
+            <button
+              onClick={handleRetry}
+              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-red-500/20 text-red-300 hover:bg-red-500/30 border border-red-500/30 transition-colors cursor-pointer"
+            >
+              Retry now
+            </button>
+            <button
+              onClick={() => setPaused((p) => !p)}
+              className="px-3 py-1.5 text-xs font-medium rounded-lg text-red-400/60 hover:text-red-300 transition-colors cursor-pointer"
+            >
+              {paused ? "Resume" : "Pause"} auto-retry
+            </button>
+            {!paused && (
+              <span className="text-xs text-red-400/50">
+                Retrying in {countdown}s
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ForceGraph.tsx
+++ b/src/components/ForceGraph.tsx
@@ -2,9 +2,8 @@ import { useRef, useEffect, useCallback } from "react";
 import * as d3 from "d3";
 import type {
   Organization,
-  Agent,
+  AgentCertificate,
   Task,
-  Fractal,
   PeerNode,
   GraphNode,
   GraphLink,
@@ -13,9 +12,8 @@ import { NODE_COLORS, truncateId } from "./utils.ts";
 
 interface Props {
   organizations: Organization[];
-  agents: Agent[];
+  agents: AgentCertificate[];
   tasks: Task[];
-  fractals: Fractal[];
   peers: PeerNode[];
   activeView: "org" | "tasks" | "peers";
   onNodeClick: (node: GraphNode) => void;
@@ -23,9 +21,8 @@ interface Props {
 
 function buildGraph(
   orgs: Organization[],
-  agents: Agent[],
+  agents: AgentCertificate[],
   tasks: Task[],
-  fractals: Fractal[],
   peers: PeerNode[],
   view: "org" | "tasks" | "peers",
 ): { nodes: GraphNode[]; links: GraphLink[] } {
@@ -33,36 +30,33 @@ function buildGraph(
   const links: GraphLink[] = [];
 
   if (view === "org" || view === "tasks") {
-    // Organization nodes
     for (const org of orgs) {
-      nodes.push({ id: org.id, label: org.name || truncateId(org.id), type: "org", data: org });
-    }
-
-    // Fractal nodes
-    for (const f of fractals) {
-      nodes.push({ id: f.id, label: f.name || truncateId(f.id), type: "fractal", data: f });
-      if (f.parent_org) {
-        links.push({ source: f.parent_org, target: f.id, type: "contains" });
+      const isSubOrg = org.depth > 0;
+      nodes.push({
+        id: org.id,
+        label: org.name || truncateId(org.id),
+        type: isSubOrg ? "suborg" : "org",
+        data: org,
+      });
+      if (org.parent_org) {
+        links.push({ source: org.parent_org, target: org.id, type: "parent" });
       }
     }
 
-    // Agent nodes
     for (const a of agents) {
       nodes.push({
         id: a.id,
-        label: a.name || truncateId(a.id),
+        label: truncateId(a.agent, 4),
         type: "agent",
         status: a.status,
         data: a,
       });
-      // Link to org
       if (a.org_id) {
         links.push({ source: a.org_id, target: a.id, type: "contains" });
       }
     }
 
     if (view === "tasks") {
-      // Task nodes
       for (const t of tasks) {
         nodes.push({
           id: t.id,
@@ -72,7 +66,14 @@ function buildGraph(
           data: t,
         });
         if (t.assignee) {
-          links.push({ source: t.assignee, target: t.id, type: "assigned" });
+          const cert = agents.find(
+            (a) => a.agent === t.assignee && a.org_id === t.org_id,
+          );
+          if (cert) {
+            links.push({ source: cert.id, target: t.id, type: "assigned" });
+          } else if (t.org_id) {
+            links.push({ source: t.org_id, target: t.id, type: "contains" });
+          }
         } else if (t.org_id) {
           links.push({ source: t.org_id, target: t.id, type: "contains" });
         }
@@ -90,7 +91,6 @@ function buildGraph(
         data: p,
       });
     }
-    // Create a mesh topology between peers
     for (let i = 0; i < peers.length; i++) {
       for (let j = i + 1; j < peers.length; j++) {
         links.push({
@@ -102,7 +102,6 @@ function buildGraph(
     }
   }
 
-  // Deduplicate: only keep links where both source and target exist in nodes
   const nodeIds = new Set(nodes.map((n) => n.id));
   const validLinks = links.filter(
     (l) => nodeIds.has(l.source as string) && nodeIds.has(l.target as string),
@@ -115,7 +114,6 @@ export default function ForceGraph({
   organizations,
   agents,
   tasks,
-  fractals,
   peers,
   activeView,
   onNodeClick,
@@ -135,18 +133,14 @@ export default function ForceGraph({
       organizations,
       agents,
       tasks,
-      fractals,
       peers,
       activeView,
     );
 
-    // Clear previous
     const sel = d3.select(svg);
     sel.selectAll("*").remove();
-
     sel.attr("viewBox", `0 0 ${width} ${height}`);
 
-    // Defs for glow effect
     const defs = sel.append("defs");
     const filter = defs.append("filter").attr("id", "glow");
     filter
@@ -159,7 +153,6 @@ export default function ForceGraph({
 
     const g = sel.append("g");
 
-    // Zoom behavior
     const zoom = d3
       .zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.2, 4])
@@ -168,7 +161,6 @@ export default function ForceGraph({
       });
     sel.call(zoom);
 
-    // Simulation
     const simulation = d3
       .forceSimulation<GraphNode>(nodes)
       .force(
@@ -182,17 +174,15 @@ export default function ForceGraph({
       .force("center", d3.forceCenter(width / 2, height / 2))
       .force("collision", d3.forceCollide().radius(30));
 
-    // Links
     const link = g
       .append("g")
       .selectAll("line")
       .data(links)
       .join("line")
-      .attr("stroke", "#374151")
+      .attr("stroke", "var(--color-graph-line)")
       .attr("stroke-width", 1.5)
       .attr("stroke-opacity", 0.6);
 
-    // Node groups
     const node = g
       .append("g")
       .selectAll<SVGGElement, GraphNode>("g")
@@ -219,25 +209,17 @@ export default function ForceGraph({
           }),
       );
 
-    // Node size by type
     const nodeRadius = (d: GraphNode) => {
       switch (d.type) {
-        case "org":
-          return 24;
-        case "fractal":
-          return 18;
-        case "agent":
-          return 16;
-        case "task":
-          return 12;
-        case "peer":
-          return 14;
-        default:
-          return 12;
+        case "org": return 24;
+        case "suborg": return 18;
+        case "agent": return 16;
+        case "task": return 12;
+        case "peer": return 14;
+        default: return 12;
       }
     };
 
-    // Circle
     node
       .append("circle")
       .attr("r", nodeRadius)
@@ -247,21 +229,14 @@ export default function ForceGraph({
       .attr("stroke-width", 2)
       .attr("filter", "url(#glow)");
 
-    // Icon text inside node
     const nodeIcon = (d: GraphNode) => {
       switch (d.type) {
-        case "org":
-          return "O";
-        case "fractal":
-          return "F";
-        case "agent":
-          return "A";
-        case "task":
-          return "T";
-        case "peer":
-          return "P";
-        default:
-          return "?";
+        case "org": return "O";
+        case "suborg": return "S";
+        case "agent": return "A";
+        case "task": return "T";
+        case "peer": return "P";
+        default: return "?";
       }
     };
 
@@ -275,34 +250,30 @@ export default function ForceGraph({
       .attr("pointer-events", "none")
       .text(nodeIcon);
 
-    // Label below node
     node
       .append("text")
       .attr("text-anchor", "middle")
       .attr("dy", (d) => nodeRadius(d) + 14)
-      .attr("fill", "#9ca3af")
+      .attr("fill", "var(--color-graph-label)")
       .attr("font-size", "10px")
       .attr("pointer-events", "none")
       .text((d) =>
         d.label.length > 16 ? d.label.slice(0, 14) + "…" : d.label,
       );
 
-    // Tick
     simulation.on("tick", () => {
       link
         .attr("x1", (d) => (d.source as unknown as GraphNode).x ?? 0)
         .attr("y1", (d) => (d.source as unknown as GraphNode).y ?? 0)
         .attr("x2", (d) => (d.target as unknown as GraphNode).x ?? 0)
         .attr("y2", (d) => (d.target as unknown as GraphNode).y ?? 0);
-
       node.attr("transform", (d) => `translate(${d.x ?? 0},${d.y ?? 0})`);
     });
 
-    // Cleanup
     return () => {
       simulation.stop();
     };
-  }, [organizations, agents, tasks, fractals, peers, activeView, onNodeClick]);
+  }, [organizations, agents, tasks, peers, activeView, onNodeClick]);
 
   useEffect(() => {
     const cleanup = render();

--- a/src/components/PeerList.tsx
+++ b/src/components/PeerList.tsx
@@ -8,7 +8,7 @@ interface Props {
 export default function PeerList({ peers }: Props) {
   if (peers.length === 0) {
     return (
-      <div className="text-center text-gray-600 py-8">
+      <div className="text-center text-muted py-8">
         No peer nodes found in PeerRegistry
       </div>
     );
@@ -20,10 +20,10 @@ export default function PeerList({ peers }: Props) {
         <button
           key={peer.id}
           onClick={() => openOnSuiScan(peer.id)}
-          className="w-full text-left bg-gray-900/50 rounded-lg border border-gray-800 p-3 hover:border-gray-700 transition-colors cursor-pointer"
+          className="w-full text-left bg-surface-alt rounded-lg border border-border p-3 hover:border-border-hover transition-colors cursor-pointer"
         >
           <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-200 font-medium">
+            <span className="text-sm text-primary font-medium">
               {peer.node_id || truncateId(peer.id)}
             </span>
             <span
@@ -42,9 +42,9 @@ export default function PeerList({ peers }: Props) {
             </span>
           </div>
           {peer.endpoint && (
-            <div className="text-xs text-gray-500 mt-1">{peer.endpoint}</div>
+            <div className="text-xs text-muted mt-1">{peer.endpoint}</div>
           )}
-          <div className="text-xs text-gray-600 mt-1 font-mono">
+          <div className="text-xs text-muted mt-1 font-mono">
             {truncateId(peer.id)}
           </div>
         </button>

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,74 @@
+/** Skeleton shimmer placeholders for loading state */
+
+export function SidebarSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      {/* View switcher skeleton */}
+      <div className="bg-surface-alt rounded-xl border border-border p-2 space-y-1">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-9 rounded-lg bg-skeleton"
+          />
+        ))}
+      </div>
+
+      {/* Legend skeleton */}
+      <div className="bg-surface-alt rounded-xl border border-border p-4">
+        <div className="h-3 w-16 bg-skeleton rounded mb-3" />
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-skeleton" />
+              <div className="h-3 w-12 bg-skeleton rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Counts skeleton */}
+      <div className="bg-surface-alt rounded-xl border border-border p-4">
+        <div className="h-3 w-24 bg-skeleton rounded mb-3" />
+        <div className="grid grid-cols-2 gap-2">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div
+              key={i}
+              className="bg-skeleton/50 rounded-lg p-2 h-14"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function GraphSkeleton() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="text-center">
+        <div className="relative w-24 h-24 mx-auto mb-4">
+          {/* Animated orbiting dots */}
+          <div className="absolute inset-0 animate-spin" style={{ animationDuration: "3s" }}>
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 w-3 h-3 rounded-full bg-fractal-500 opacity-80" />
+          </div>
+          <div className="absolute inset-0 animate-spin" style={{ animationDuration: "3s", animationDelay: "-1s" }}>
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 w-2.5 h-2.5 rounded-full bg-green-400 opacity-80" />
+          </div>
+          <div className="absolute inset-0 animate-spin" style={{ animationDuration: "3s", animationDelay: "-2s" }}>
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-yellow-400 opacity-80" />
+          </div>
+          {/* Center dot */}
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="w-4 h-4 rounded-full bg-fractal-400 animate-pulse-dot" />
+          </div>
+        </div>
+        <div className="text-sm text-secondary font-medium">
+          Fetching on-chain data...
+        </div>
+        <div className="text-xs text-muted mt-1">
+          Traversing SUI Testnet tables
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskFlow.tsx
+++ b/src/components/TaskFlow.tsx
@@ -5,10 +5,15 @@ interface Props {
   tasks: Task[];
 }
 
-const STEPS = ["created", "assigned", "submitted", "verified", "completed"] as const;
+const STEPS = [
+  "created",
+  "assigned",
+  "submitted",
+  "verified",
+  "completed",
+] as const;
 
 export default function TaskFlow({ tasks }: Props) {
-  // Count tasks at each stage
   const counts = Object.fromEntries(STEPS.map((s) => [s, 0]));
   for (const t of tasks) {
     if (t.status in counts) counts[t.status]++;
@@ -16,9 +21,8 @@ export default function TaskFlow({ tasks }: Props) {
 
   return (
     <div className="space-y-4">
-      {/* Pipeline overview */}
-      <div className="bg-gray-900/50 rounded-xl border border-gray-800 p-4">
-        <h3 className="text-sm font-medium text-gray-400 mb-3">
+      <div className="bg-surface-alt rounded-xl border border-border p-4">
+        <h3 className="text-sm font-medium text-secondary mb-3">
           Task Pipeline
         </h3>
         <div className="flex items-center justify-between">
@@ -35,22 +39,21 @@ export default function TaskFlow({ tasks }: Props) {
                 >
                   {counts[step]}
                 </div>
-                <div className="text-[10px] text-gray-500 mt-1 capitalize">
+                <div className="text-[10px] text-muted mt-1 capitalize">
                   {step}
                 </div>
               </div>
               {i < STEPS.length - 1 && (
-                <div className="w-8 h-0.5 bg-gray-700 mx-1" />
+                <div className="w-8 h-0.5 bg-border mx-1" />
               )}
             </div>
           ))}
         </div>
       </div>
 
-      {/* Task list */}
       <div className="space-y-2">
         {tasks.length === 0 && (
-          <div className="text-center text-gray-600 py-8">
+          <div className="text-center text-muted py-8">
             No tasks found on-chain
           </div>
         )}
@@ -58,10 +61,10 @@ export default function TaskFlow({ tasks }: Props) {
           <button
             key={task.id}
             onClick={() => openOnSuiScan(task.id)}
-            className="w-full text-left bg-gray-900/50 rounded-lg border border-gray-800 p-3 hover:border-gray-700 transition-colors cursor-pointer"
+            className="w-full text-left bg-surface-alt rounded-lg border border-border p-3 hover:border-border-hover transition-colors cursor-pointer"
           >
             <div className="flex items-center justify-between">
-              <span className="text-sm text-gray-200 font-medium">
+              <span className="text-sm text-primary font-medium">
                 {task.title || truncateId(task.id)}
               </span>
               <span
@@ -75,7 +78,7 @@ export default function TaskFlow({ tasks }: Props) {
                 {task.status}
               </span>
             </div>
-            <div className="text-xs text-gray-500 mt-1 font-mono">
+            <div className="text-xs text-muted mt-1 font-mono">
               {truncateId(task.id)}
             </div>
           </button>

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -14,7 +14,7 @@ export function openOnSuiScan(objectId: string) {
 /** Color mapping for node types */
 export const NODE_COLORS: Record<string, string> = {
   org: "#4c6ef5",
-  fractal: "#7950f2",
+  suborg: "#7950f2",
   agent: "#20c997",
   task: "#fcc419",
   peer: "#ff6b6b",

--- a/src/hooks/useSuiData.ts
+++ b/src/hooks/useSuiData.ts
@@ -6,7 +6,6 @@ const EMPTY: ExplorerData = {
   organizations: [],
   agents: [],
   tasks: [],
-  fractals: [],
   peers: [],
   loading: true,
   error: null,

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect, useCallback } from "react";
+
+export type Theme = "dark" | "light";
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+  const stored = localStorage.getItem("fm-explorer-theme");
+  if (stored === "light" || stored === "dark") return stored;
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("fm-explorer-theme", theme);
+  }, [theme]);
+
+  const toggle = useCallback(() => {
+    setThemeState((t) => (t === "dark" ? "light" : "dark"));
+  }, []);
+
+  return { theme, toggle };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,22 +3,44 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --color-node-org: #4c6ef5;
-    --color-node-fractal: #7950f2;
-    --color-node-agent: #20c997;
-    --color-node-task: #fcc419;
-    --color-node-peer: #ff6b6b;
+  /* ── Dark theme (default) ─────────────────────────── */
+  :root,
+  [data-theme="dark"] {
+    --color-bg: #030712;
+    --color-surface: #111827;
+    --color-surface-alt: rgba(17, 24, 39, 0.5);
+    --color-hover: rgba(31, 41, 55, 1);
+    --color-border: #1f2937;
+    --color-border-hover: #374151;
+    --color-primary: #f3f4f6;
+    --color-secondary: #9ca3af;
+    --color-muted: #6b7280;
+    --color-skeleton: rgba(55, 65, 81, 0.5);
+    --color-graph-line: #374151;
+    --color-graph-label: #9ca3af;
+  }
+
+  /* ── Light theme ──────────────────────────────────── */
+  [data-theme="light"] {
+    --color-bg: #f9fafb;
+    --color-surface: #ffffff;
+    --color-surface-alt: rgba(255, 255, 255, 0.7);
+    --color-hover: rgba(243, 244, 246, 1);
+    --color-border: #e5e7eb;
+    --color-border-hover: #d1d5db;
+    --color-primary: #111827;
+    --color-secondary: #4b5563;
+    --color-muted: #9ca3af;
+    --color-skeleton: rgba(209, 213, 219, 0.5);
+    --color-graph-line: #d1d5db;
+    --color-graph-label: #6b7280;
   }
 }
 
 body {
   font-family: "Inter", system-ui, -apple-system, sans-serif;
-}
-
-/* Force-graph canvas styling */
-.force-graph-container canvas {
-  border-radius: 0.75rem;
+  background-color: var(--color-bg);
+  color: var(--color-primary);
 }
 
 /* Custom scrollbar */
@@ -29,24 +51,45 @@ body {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: #4b5563;
+  background: var(--color-muted);
   border-radius: 3px;
 }
 
 /* Pulse animation for live status */
 @keyframes pulse-dot {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 .animate-pulse-dot {
   animation: pulse-dot 2s ease-in-out infinite;
 }
 
-/* Task flow step animations */
+/* Slide-in animation */
 @keyframes flow-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 .animate-flow-in {
-  animation: flow-in 0.3s ease-out forwards;
+  animation: flow-in 0.25s ease-out forwards;
+}
+
+/* Skeleton shimmer */
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
 }

--- a/src/sui/queries.ts
+++ b/src/sui/queries.ts
@@ -2,22 +2,24 @@ import { SuiClient, SuiObjectResponse } from "@mysten/sui/client";
 import { SUI_CONFIG } from "./config.ts";
 import type {
   Organization,
-  Agent,
+  AgentCertificate,
   Task,
-  Fractal,
   PeerNode,
 } from "./types.ts";
+import { TASK_STATUS_MAP, AGENT_STATUS_MAP } from "./types.ts";
 
 const client = new SuiClient({ url: SUI_CONFIG.rpcUrl });
 
-/** Extract typed fields from a SUI object response */
-function extractFields(resp: SuiObjectResponse): Record<string, unknown> | null {
+// ── Low-level helpers ──────────────────────────────────────────────
+
+function extractFields(
+  resp: SuiObjectResponse,
+): Record<string, unknown> | null {
   const data = resp.data;
   if (!data?.content || data.content.dataType !== "moveObject") return null;
   return (data.content as { fields: Record<string, unknown> }).fields ?? null;
 }
 
-/** Read a single object by ID with full content */
 async function getObject(objectId: string): Promise<SuiObjectResponse> {
   return client.getObject({
     id: objectId,
@@ -25,13 +27,69 @@ async function getObject(objectId: string): Promise<SuiObjectResponse> {
   });
 }
 
-/** Read multiple objects in a single batch */
 async function multiGetObjects(ids: string[]): Promise<SuiObjectResponse[]> {
   if (ids.length === 0) return [];
-  return client.multiGetObjects({
-    ids,
-    options: { showContent: true, showType: true, showOwner: true },
-  });
+  const results: SuiObjectResponse[] = [];
+  for (let i = 0; i < ids.length; i += 50) {
+    const batch = ids.slice(i, i + 50);
+    const resp = await client.multiGetObjects({
+      ids: batch,
+      options: { showContent: true, showType: true, showOwner: true },
+    });
+    results.push(...resp);
+  }
+  return results;
+}
+
+/**
+ * Traverse all keys from a SUI Table via getDynamicFields.
+ * Tables store entries as dynamic fields on the table's UID.
+ */
+async function getTableKeys(tableId: string): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor: string | null = null;
+  let hasNext = true;
+
+  while (hasNext) {
+    const page = await client.getDynamicFields({
+      parentId: tableId,
+      cursor: cursor ?? undefined,
+      limit: 50,
+    });
+    for (const entry of page.data) {
+      keys.push(String(entry.name.value));
+    }
+    cursor = page.nextCursor ?? null;
+    hasNext = page.hasNextPage;
+  }
+
+  return keys;
+}
+
+/**
+ * Get dynamic field objects from a Table (for Tables with non-bool values).
+ */
+async function getTableDynamicFieldObjects(
+  tableId: string,
+): Promise<SuiObjectResponse[]> {
+  const objectIds: string[] = [];
+  let cursor: string | null = null;
+  let hasNext = true;
+
+  while (hasNext) {
+    const page = await client.getDynamicFields({
+      parentId: tableId,
+      cursor: cursor ?? undefined,
+      limit: 50,
+    });
+    for (const entry of page.data) {
+      objectIds.push(entry.objectId);
+    }
+    cursor = page.nextCursor ?? null;
+    hasNext = page.hasNextPage;
+  }
+
+  return multiGetObjects(objectIds);
 }
 
 // ── Field helpers ──────────────────────────────────────────────────
@@ -40,18 +98,46 @@ function getString(fields: Record<string, unknown>, key: string): string {
   return String(fields[key] ?? "");
 }
 
+function getOptionalString(
+  fields: Record<string, unknown>,
+  key: string,
+): string | null {
+  const val = fields[key];
+  if (val === null || val === undefined) return null;
+  return String(val);
+}
+
+function getNumber(fields: Record<string, unknown>, key: string): number {
+  return Number(fields[key] ?? 0);
+}
+
 function getStringArray(
   fields: Record<string, unknown>,
   key: string,
 ): string[] {
   const val = fields[key];
   if (Array.isArray(val)) return val.map(String);
-  // SUI stores Vec as { type: "...", fields: { contents: [...] } }
-  if (val && typeof val === "object" && "fields" in val) {
-    const inner = (val as { fields: { contents?: unknown[] } }).fields;
-    if (Array.isArray(inner?.contents)) return inner.contents.map(String);
-  }
   return [];
+}
+
+/** Extract the inner UID from a Table field */
+function getTableId(
+  fields: Record<string, unknown>,
+  key: string,
+): string | null {
+  const table = fields[key];
+  if (!table || typeof table !== "object") return null;
+  const tableObj = table as {
+    fields?: { id?: { id?: string }; size?: string };
+  };
+  return tableObj.fields?.id?.id ?? null;
+}
+
+function getTableSize(fields: Record<string, unknown>, key: string): number {
+  const table = fields[key];
+  if (!table || typeof table !== "object") return 0;
+  const tableObj = table as { fields?: { size?: string } };
+  return Number(tableObj.fields?.size ?? 0);
 }
 
 // ── Parse functions ────────────────────────────────────────────────
@@ -65,58 +151,51 @@ function parseOrganization(
     name: getString(fields, "name"),
     description: getString(fields, "description"),
     admin: getString(fields, "admin"),
-    agents: getStringArray(fields, "agents"),
-    fractals: getStringArray(fields, "fractals"),
-    tasks: getStringArray(fields, "tasks"),
+    depth: getNumber(fields, "depth"),
+    is_active: fields["is_active"] === true,
+    parent_org: getOptionalString(fields, "parent_org"),
+    agent_count: getTableSize(fields, "agents"),
+    task_count: getTableSize(fields, "tasks"),
+    child_org_count: getTableSize(fields, "child_orgs"),
+    agent_addresses: [],
+    task_ids: [],
+    child_org_ids: [],
     created_at: getString(fields, "created_at"),
   };
 }
 
-function parseAgent(id: string, fields: Record<string, unknown>): Agent {
-  const statusRaw = getString(fields, "status").toLowerCase();
-  const status = (["active", "idle", "suspended", "offline"].includes(statusRaw)
-    ? statusRaw
-    : "idle") as Agent["status"];
+function parseAgentCertificate(
+  id: string,
+  fields: Record<string, unknown>,
+): AgentCertificate {
+  const statusNum = getNumber(fields, "status");
   return {
     id,
-    name: getString(fields, "name"),
-    role: getString(fields, "role"),
-    status,
+    agent: getString(fields, "agent"),
     org_id: getString(fields, "org_id"),
-    capabilities: getStringArray(fields, "capabilities"),
-    tasks_assigned: getStringArray(fields, "tasks_assigned"),
-    created_at: getString(fields, "created_at"),
+    capability_tags: getStringArray(fields, "capability_tags"),
+    reputation_score: getNumber(fields, "reputation_score"),
+    status: AGENT_STATUS_MAP[statusNum] ?? "idle",
+    tasks_completed: getNumber(fields, "tasks_completed"),
   };
 }
 
 function parseTask(id: string, fields: Record<string, unknown>): Task {
-  const statusRaw = getString(fields, "status").toLowerCase();
-  const validStatuses = ["created", "assigned", "submitted", "verified", "completed"];
-  const status = (validStatuses.includes(statusRaw)
-    ? statusRaw
-    : "created") as Task["status"];
+  const statusNum = getNumber(fields, "status");
   return {
     id,
     title: getString(fields, "title"),
     description: getString(fields, "description"),
-    status,
+    status: TASK_STATUS_MAP[statusNum] ?? "created",
     org_id: getString(fields, "org_id"),
-    assignee: fields["assignee"] ? getString(fields, "assignee") : null,
+    assignee: getOptionalString(fields, "assignee"),
     creator: getString(fields, "creator"),
+    verifier: getOptionalString(fields, "verifier"),
+    submission: getOptionalString(fields, "submission"),
     created_at: getString(fields, "created_at"),
-    updated_at: getString(fields, "updated_at"),
-  };
-}
-
-function parseFractal(id: string, fields: Record<string, unknown>): Fractal {
-  return {
-    id,
-    name: getString(fields, "name"),
-    parent_org: getString(fields, "parent_org"),
-    depth: Number(fields["depth"] ?? 0),
-    agents: getStringArray(fields, "agents"),
-    sub_fractals: getStringArray(fields, "sub_fractals"),
-    created_at: getString(fields, "created_at"),
+    assigned_at: getOptionalString(fields, "assigned_at"),
+    submitted_at: getOptionalString(fields, "submitted_at"),
+    completed_at: getOptionalString(fields, "completed_at"),
   };
 }
 
@@ -125,9 +204,11 @@ function parsePeerNode(
   fields: Record<string, unknown>,
 ): PeerNode {
   const statusRaw = getString(fields, "status").toLowerCase();
-  const status = (["online", "offline", "syncing"].includes(statusRaw)
-    ? statusRaw
-    : "offline") as PeerNode["status"];
+  const status = (
+    ["online", "offline", "syncing"].includes(statusRaw)
+      ? statusRaw
+      : "offline"
+  ) as PeerNode["status"];
   return {
     id,
     node_id: getString(fields, "node_id"),
@@ -140,58 +221,91 @@ function parsePeerNode(
 
 // ── Public query API ───────────────────────────────────────────────
 
-/** Fetch the Registry and discover all referenced objects */
-export async function fetchRegistry(): Promise<{
-  orgIds: string[];
-  agentIds: string[];
-  taskIds: string[];
-  fractalIds: string[];
-}> {
+async function fetchOrgIdsFromRegistry(): Promise<string[]> {
   const resp = await getObject(SUI_CONFIG.registry);
   const fields = extractFields(resp);
-  if (!fields) {
-    return { orgIds: [], agentIds: [], taskIds: [], fractalIds: [] };
+  if (!fields) return [];
+
+  const orgsTableId = getTableId(fields, "organizations");
+  if (!orgsTableId) return [];
+
+  return getTableKeys(orgsTableId);
+}
+
+async function fetchOrganizationsWithTables(
+  orgIds: string[],
+): Promise<Organization[]> {
+  const responses = await multiGetObjects(orgIds);
+  const orgs: Organization[] = [];
+
+  for (const r of responses) {
+    const id = r.data?.objectId;
+    const fields = extractFields(r);
+    if (!id || !fields) continue;
+
+    const org = parseOrganization(id, fields);
+
+    const agentsTableId = getTableId(fields, "agents");
+    if (agentsTableId && org.agent_count > 0) {
+      org.agent_addresses = await getTableKeys(agentsTableId);
+    }
+
+    const tasksTableId = getTableId(fields, "tasks");
+    if (tasksTableId && org.task_count > 0) {
+      org.task_ids = await getTableKeys(tasksTableId);
+    }
+
+    const childOrgsTableId = getTableId(fields, "child_orgs");
+    if (childOrgsTableId && org.child_org_count > 0) {
+      org.child_org_ids = await getTableKeys(childOrgsTableId);
+    }
+
+    orgs.push(org);
   }
 
-  return {
-    orgIds: getStringArray(fields, "organizations"),
-    agentIds: getStringArray(fields, "agents"),
-    taskIds: getStringArray(fields, "tasks"),
-    fractalIds: getStringArray(fields, "fractals"),
-  };
+  return orgs;
 }
 
-/** Fetch Organizations by their IDs */
-export async function fetchOrganizations(
-  ids: string[],
-): Promise<Organization[]> {
-  const responses = await multiGetObjects(ids);
-  return responses
-    .map((r) => {
-      const id = r.data?.objectId;
-      const fields = extractFields(r);
-      if (!id || !fields) return null;
-      return parseOrganization(id, fields);
-    })
-    .filter((o): o is Organization => o !== null);
+async function fetchAgentCertificates(
+  agentAddresses: string[],
+): Promise<AgentCertificate[]> {
+  const certs: AgentCertificate[] = [];
+  const seen = new Set<string>();
+
+  for (const addr of agentAddresses) {
+    let cursor: string | null = null;
+    let hasNext = true;
+
+    while (hasNext) {
+      const page = await client.getOwnedObjects({
+        owner: addr,
+        filter: {
+          StructType: `${SUI_CONFIG.protocolPackage}::agent::AgentCertificate`,
+        },
+        options: { showContent: true, showType: true },
+        cursor: cursor ?? undefined,
+        limit: 50,
+      });
+
+      for (const item of page.data) {
+        const id = item.data?.objectId;
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        const fields = extractFields(item);
+        if (!fields) continue;
+        certs.push(parseAgentCertificate(id, fields));
+      }
+
+      cursor = page.nextCursor ?? null;
+      hasNext = page.hasNextPage;
+    }
+  }
+
+  return certs;
 }
 
-/** Fetch Agents by their IDs */
-export async function fetchAgents(ids: string[]): Promise<Agent[]> {
-  const responses = await multiGetObjects(ids);
-  return responses
-    .map((r) => {
-      const id = r.data?.objectId;
-      const fields = extractFields(r);
-      if (!id || !fields) return null;
-      return parseAgent(id, fields);
-    })
-    .filter((a): a is Agent => a !== null);
-}
-
-/** Fetch Tasks by their IDs */
-export async function fetchTasks(ids: string[]): Promise<Task[]> {
-  const responses = await multiGetObjects(ids);
+async function fetchTasks(taskIds: string[]): Promise<Task[]> {
+  const responses = await multiGetObjects(taskIds);
   return responses
     .map((r) => {
       const id = r.data?.objectId;
@@ -202,52 +316,51 @@ export async function fetchTasks(ids: string[]): Promise<Task[]> {
     .filter((t): t is Task => t !== null);
 }
 
-/** Fetch Fractals by their IDs */
-export async function fetchFractals(ids: string[]): Promise<Fractal[]> {
-  const responses = await multiGetObjects(ids);
-  return responses
-    .map((r) => {
-      const id = r.data?.objectId;
-      const fields = extractFields(r);
-      if (!id || !fields) return null;
-      return parseFractal(id, fields);
-    })
-    .filter((f): f is Fractal => f !== null);
-}
-
-/** Fetch the PeerRegistry and discover peer nodes */
-export async function fetchPeerRegistry(): Promise<PeerNode[]> {
+async function fetchPeerNodes(): Promise<PeerNode[]> {
   const resp = await getObject(SUI_CONFIG.peerRegistry);
   const fields = extractFields(resp);
   if (!fields) return [];
 
-  const peerIds = getStringArray(fields, "peers");
-  if (peerIds.length === 0) return [];
+  const peersTableId = getTableId(fields, "peers");
+  const peerCount = getTableSize(fields, "peers");
+  if (!peersTableId || peerCount === 0) return [];
 
-  const responses = await multiGetObjects(peerIds);
-  return responses
-    .map((r) => {
-      const id = r.data?.objectId;
-      const f = extractFields(r);
-      if (!id || !f) return null;
-      return parsePeerNode(id, f);
-    })
-    .filter((p): p is PeerNode => p !== null);
+  const dfObjects = await getTableDynamicFieldObjects(peersTableId);
+  const peers: PeerNode[] = [];
+
+  for (const obj of dfObjects) {
+    const objFields = extractFields(obj);
+    if (!objFields) continue;
+    const valueObj = objFields["value"];
+    if (!valueObj || typeof valueObj !== "object") continue;
+    const peerFields = (valueObj as { fields?: Record<string, unknown> })
+      .fields;
+    if (!peerFields) continue;
+    const id = obj.data?.objectId ?? "";
+    peers.push(parsePeerNode(id, peerFields));
+  }
+
+  return peers;
 }
 
-/** Fetch all data from the chain in one call */
+/** Fetch all data from the chain using Table-aware dynamic field traversal */
 export async function fetchAllData() {
-  // 1) Read registry to discover object IDs
-  const registry = await fetchRegistry();
+  const orgIds = await fetchOrgIdsFromRegistry();
+  const organizations = await fetchOrganizationsWithTables(orgIds);
 
-  // 2) Fetch all objects in parallel
-  const [organizations, agents, tasks, fractals, peers] = await Promise.all([
-    fetchOrganizations(registry.orgIds),
-    fetchAgents(registry.agentIds),
-    fetchTasks(registry.taskIds),
-    fetchFractals(registry.fractalIds),
-    fetchPeerRegistry(),
+  const allAgentAddresses = new Set<string>();
+  const allTaskIds = new Set<string>();
+
+  for (const org of organizations) {
+    for (const addr of org.agent_addresses) allAgentAddresses.add(addr);
+    for (const tid of org.task_ids) allTaskIds.add(tid);
+  }
+
+  const [agents, tasks, peers] = await Promise.all([
+    fetchAgentCertificates([...allAgentAddresses]),
+    fetchTasks([...allTaskIds]),
+    fetchPeerNodes(),
   ]);
 
-  return { organizations, agents, tasks, fractals, peers };
+  return { organizations, agents, tasks, peers };
 }

--- a/src/sui/types.ts
+++ b/src/sui/types.ts
@@ -1,28 +1,53 @@
-/** TypeScript types mirroring on-chain Move structs */
+/**
+ * TypeScript types mirroring actual on-chain Move structs.
+ *
+ * Key facts about the on-chain data model:
+ * - Registry and Organization use 0x2::table::Table (not vectors)
+ * - Child orgs are Organization objects with depth > 0 (no separate Fractal type)
+ * - Agents are tracked by address; details come from AgentCertificate owned objects
+ * - Task status is a u8 (0-4), mapped to string here
+ * - PeerRegistry.peers is also a Table
+ */
 
 export interface Organization {
   id: string;
   name: string;
   description: string;
   admin: string;
-  agents: string[];
-  fractals: string[];
-  tasks: string[];
+  depth: number;
+  is_active: boolean;
+  parent_org: string | null;
+  agent_count: number;
+  task_count: number;
+  child_org_count: number;
+  /** Resolved from agents Table<address, bool> via dynamic fields */
+  agent_addresses: string[];
+  /** Resolved from tasks Table<ID, bool> via dynamic fields */
+  task_ids: string[];
+  /** Resolved from child_orgs Table<ID, bool> via dynamic fields */
+  child_org_ids: string[];
   created_at: string;
 }
 
-export interface Agent {
+export interface AgentCertificate {
   id: string;
-  name: string;
-  role: string;
-  status: AgentStatus;
+  agent: string;
   org_id: string;
-  capabilities: string[];
-  tasks_assigned: string[];
-  created_at: string;
+  capability_tags: string[];
+  reputation_score: number;
+  status: AgentStatus;
+  tasks_completed: number;
 }
 
+/** Agent status u8: 0 = active, 1 = idle, 2 = suspended, 3 = offline */
 export type AgentStatus = "active" | "idle" | "suspended" | "offline";
+
+export const AGENT_STATUS_MAP: Record<number, AgentStatus> = {
+  0: "active",
+  1: "idle",
+  2: "suspended",
+  3: "offline",
+};
 
 export interface Task {
   id: string;
@@ -32,10 +57,15 @@ export interface Task {
   org_id: string;
   assignee: string | null;
   creator: string;
+  verifier: string | null;
+  submission: string | null;
   created_at: string;
-  updated_at: string;
+  assigned_at: string | null;
+  submitted_at: string | null;
+  completed_at: string | null;
 }
 
+/** Task status u8: 0=created, 1=assigned, 2=submitted, 3=verified, 4=completed */
 export type TaskStatus =
   | "created"
   | "assigned"
@@ -43,15 +73,13 @@ export type TaskStatus =
   | "verified"
   | "completed";
 
-export interface Fractal {
-  id: string;
-  name: string;
-  parent_org: string;
-  depth: number;
-  agents: string[];
-  sub_fractals: string[];
-  created_at: string;
-}
+export const TASK_STATUS_MAP: Record<number, TaskStatus> = {
+  0: "created",
+  1: "assigned",
+  2: "submitted",
+  3: "verified",
+  4: "completed",
+};
 
 export interface PeerNode {
   id: string;
@@ -66,9 +94,9 @@ export interface PeerNode {
 export interface GraphNode {
   id: string;
   label: string;
-  type: "org" | "fractal" | "agent" | "task" | "peer";
+  type: "org" | "suborg" | "agent" | "task" | "peer";
   status?: string;
-  data: Organization | Agent | Task | Fractal | PeerNode;
+  data: Organization | AgentCertificate | Task | PeerNode;
   x?: number;
   y?: number;
   fx?: number | null;
@@ -83,9 +111,8 @@ export interface GraphLink {
 
 export interface ExplorerData {
   organizations: Organization[];
-  agents: Agent[];
+  agents: AgentCertificate[];
   tasks: Task[];
-  fractals: Fractal[];
   peers: PeerNode[];
   loading: boolean;
   error: string | null;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,22 @@ export default {
           900: "#364fc7",
         },
       },
+      textColor: {
+        primary: "var(--color-primary)",
+        secondary: "var(--color-secondary)",
+        muted: "var(--color-muted)",
+      },
+      backgroundColor: {
+        base: "var(--color-bg)",
+        surface: "var(--color-surface)",
+        "surface-alt": "var(--color-surface-alt)",
+        hover: "var(--color-hover)",
+        skeleton: "var(--color-skeleton)",
+      },
+      borderColor: {
+        border: "var(--color-border)",
+        "border-hover": "var(--color-border-hover)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

- **Fix SUI query layer**: Rewrite `queries.ts` to use `getDynamicFields` for Table traversal instead of assuming vector arrays. Registry, Organization agents/tasks/child_orgs all use `0x2::table::Table` on-chain — the previous code silently returned empty arrays.
- **Enable GitHub Pages**: Pages was not configured on the repo (deploy action was failing with 404). Enabled via API with `build_type=workflow`.
- **Loading skeleton**: Animated shimmer placeholders for sidebar and orbiting-dot animation for graph during first data load.
- **Error retry UI**: Auto-retry with 15s countdown, pause/resume toggle, and manual retry button. Shows the actual error message.
- **Dark/light theme toggle**: CSS custom properties with `localStorage` persistence and `prefers-color-scheme` system detection. Toggle button in header.

## Data layer changes

| Before (broken) | After (working) |
|---|---|
| `getStringArray(fields, "organizations")` | `getDynamicFields` on Table UID |
| Fractal type (never existed on-chain) | Sub-orgs = Organization with depth > 0 |
| Agent type (doesn't exist) | AgentCertificate owned objects |
| Task status as string | `u8` mapped via `TASK_STATUS_MAP` |

Verified against live SUI Testnet: 4 orgs, 5 agent certs, 7 tasks fetched correctly.

## New files

- `src/components/Skeleton.tsx` — `SidebarSkeleton` + `GraphSkeleton`
- `src/components/ErrorRetry.tsx` — auto-retry error banner
- `src/hooks/useTheme.ts` — dark/light theme with localStorage

## Test plan

- [ ] `npm run build` passes (tsc + vite)
- [ ] `npm test` passes (1 test file, 2 tests)
- [ ] Merge triggers GitHub Pages deployment successfully
- [ ] Visit `fractalmind-ai.github.io/explorer` — app loads, shows data
- [ ] Toggle dark/light theme — persists on reload
- [ ] Disconnect network, reload — error retry UI appears with countdown
- [ ] Click nodes — detail panel shows correct AgentCertificate / Task / Org data
- [ ] SuiScan links open correct testnet objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)