### PR TITLE
feat: 3D BabylonJS visualization + AgentProfile display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "fractalmind-explorer",
       "version": "0.1.0",
       "dependencies": {
+        "@babylonjs/core": "^8.54.1",
+        "@babylonjs/gui": "^8.54.1",
+        "@babylonjs/materials": "^8.54.1",
         "@mysten/sui": "^1.45.2",
         "d3": "^7.9.0",
         "react": "^19.0.0",
@@ -347,6 +350,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babylonjs/core": {
+      "version": "8.54.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-8.54.1.tgz",
+      "integrity": "sha512-1GDLlNkQ3pG9DlQSzt1SOy41Ub3c+cXhvmrYB1q5FYENolC0NUuPpTRxEl2LipVTgcxqKqyn1QcTwe+E7oXn6g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@babylonjs/gui": {
+      "version": "8.54.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-8.54.1.tgz",
+      "integrity": "sha512-S1sGd1KjNSTknTsT0UmH8bnfs4Sh/lVNigZIW4XlnNLNYsX8dKZzvZO1ntTyIWeiQOwfRHnwr8DofUdHIpD6rg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@babylonjs/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babylonjs/materials": {
+      "version": "8.54.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-8.54.1.tgz",
+      "integrity": "sha512-1KvfLd8erh8d5TzGLJy/GqBAcPKvc2tw5E8m2ZIT4QR5UvrWzjdy38FEe2etIpzy17haIUqXjiTG0KcpIJ+wgw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@babylonjs/core": "^8.6.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@babylonjs/core": "^8.54.1",
+    "@babylonjs/gui": "^8.54.1",
+    "@babylonjs/materials": "^8.54.1",
     "@mysten/sui": "^1.45.2",
     "d3": "^7.9.0",
     "react": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { useSuiData } from "./hooks/useSuiData.ts";
 import { useTheme } from "./hooks/useTheme.ts";
 import ForceGraph from "./components/ForceGraph.tsx";
+import BabylonGraph from "./components/BabylonGraph.tsx";
 import DetailPanel, { type DetailItem } from "./components/DetailPanel.tsx";
 import TaskFlow from "./components/TaskFlow.tsx";
 import PeerList from "./components/PeerList.tsx";
@@ -23,6 +24,7 @@ export default function App() {
   const data = useSuiData();
   const { theme, toggle: toggleTheme } = useTheme();
   const [activeView, setActiveView] = useState<View>("org");
+  const [renderMode, setRenderMode] = useState<"2d" | "3d">("3d");
   const [selectedNode, setSelectedNode] = useState<DetailItem | null>(null);
 
   const handleNodeClick = useCallback((node: GraphNode) => {
@@ -266,17 +268,38 @@ export default function App() {
             <ErrorRetry error={data.error} onRetry={data.refresh} />
           )}
 
-          {/* Force graph */}
+          {/* Force graph / 3D graph */}
           <div className="flex-1 bg-surface-alt rounded-xl border border-border overflow-hidden relative min-h-[400px]">
             {isFirstLoad && <GraphSkeleton />}
-            <ForceGraph
-              organizations={data.organizations}
-              agents={data.agents}
-              tasks={data.tasks}
-              peers={data.peers}
-              activeView={activeView}
-              onNodeClick={handleNodeClick}
-            />
+
+            {/* 2D/3D toggle */}
+            <button
+              onClick={() => setRenderMode((m) => (m === "2d" ? "3d" : "2d"))}
+              className="absolute top-3 right-3 z-10 px-3 py-1.5 rounded-lg bg-base/80 backdrop-blur-sm border border-border text-xs font-medium text-secondary hover:text-primary hover:bg-hover transition-colors cursor-pointer"
+              title={`Switch to ${renderMode === "3d" ? "2D" : "3D"} view`}
+            >
+              {renderMode === "3d" ? "2D" : "3D"}
+            </button>
+
+            {renderMode === "2d" ? (
+              <ForceGraph
+                organizations={data.organizations}
+                agents={data.agents}
+                tasks={data.tasks}
+                peers={data.peers}
+                activeView={activeView}
+                onNodeClick={handleNodeClick}
+              />
+            ) : (
+              <BabylonGraph
+                organizations={data.organizations}
+                agents={data.agents}
+                tasks={data.tasks}
+                peers={data.peers}
+                activeView={activeView}
+                onNodeClick={handleNodeClick}
+              />
+            )}
           </div>
 
           {/* Bottom panel for task/peer lists */}
@@ -298,7 +321,7 @@ export default function App() {
 
       {/* Footer */}
       <footer className="border-t border-border py-3 text-center text-xs text-muted">
-        FractalMind Explorer — Built with React + D3.js + SUI SDK — Data from{" "}
+        FractalMind Explorer — Built with React + BabylonJS + D3.js + SUI SDK — Data from{" "}
         <a
           href="https://suiscan.xyz/testnet"
           target="_blank"

--- a/src/components/BabylonGraph.tsx
+++ b/src/components/BabylonGraph.tsx
@@ -1,0 +1,282 @@
+import { useRef, useEffect } from "react";
+import { Engine } from "@babylonjs/core/Engines/engine";
+import { Scene } from "@babylonjs/core/scene";
+import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
+import { Vector3, Color3, Color4 } from "@babylonjs/core/Maths/math";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { ActionManager } from "@babylonjs/core/Actions/actionManager";
+import { ExecuteCodeAction } from "@babylonjs/core/Actions/directActions";
+import { AdvancedDynamicTexture } from "@babylonjs/gui/2D/advancedDynamicTexture";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type {
+  Organization,
+  AgentCertificate,
+  Task,
+  PeerNode,
+  GraphNode,
+} from "../sui/types.ts";
+import { NODE_COLORS } from "./utils.ts";
+import { buildGraph } from "./graphUtils.ts";
+import { layout3d } from "./layout3d.ts";
+
+interface Props {
+  organizations: Organization[];
+  agents: AgentCertificate[];
+  tasks: Task[];
+  peers: PeerNode[];
+  activeView: "org" | "tasks" | "peers";
+  onNodeClick: (node: GraphNode) => void;
+}
+
+function hexToColor3(hex: string): Color3 {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  return new Color3(r, g, b);
+}
+
+function nodeRadius(type: GraphNode["type"], data: GraphNode["data"]): number {
+  switch (type) {
+    case "org": {
+      const org = data as Organization;
+      return Math.min(0.5 + (org.agent_count ?? 0) * 0.06, 0.9);
+    }
+    case "suborg":
+      return 0.4;
+    case "agent":
+      return 0.35;
+    case "task":
+      return 0.25;
+    case "peer":
+      return 0.3;
+    default:
+      return 0.25;
+  }
+}
+
+const GRAPH_TAG = "isGraph";
+
+export default function BabylonGraph({
+  organizations,
+  agents,
+  tasks,
+  peers,
+  activeView,
+  onNodeClick,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const engineRef = useRef<Engine | null>(null);
+  const sceneRef = useRef<Scene | null>(null);
+  const guiRef = useRef<AdvancedDynamicTexture | null>(null);
+
+  // Mount engine/scene/camera/lights once
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const engine = new Engine(canvas, true, { adaptToDeviceRatio: true });
+    engineRef.current = engine;
+
+    const scene = new Scene(engine);
+    scene.clearColor = new Color4(3 / 255, 7 / 255, 18 / 255, 1); // #030712
+    sceneRef.current = scene;
+
+    const camera = new ArcRotateCamera(
+      "camera",
+      Math.PI / 4,
+      Math.PI / 3,
+      20,
+      Vector3.Zero(),
+      scene,
+    );
+    camera.attachControl(canvas, true);
+    camera.lowerRadiusLimit = 3;
+    camera.upperRadiusLimit = 100;
+    camera.wheelPrecision = 20;
+    camera.panningSensibility = 100;
+
+    new HemisphericLight("light", new Vector3(0, 1, 0.5), scene);
+
+    const gui = AdvancedDynamicTexture.CreateFullscreenUI("UI", true, scene);
+    guiRef.current = gui;
+
+    engine.runRenderLoop(() => scene.render());
+
+    const container = canvas.parentElement;
+    let resizeObserver: ResizeObserver | undefined;
+    if (container) {
+      resizeObserver = new ResizeObserver(() => engine.resize());
+      resizeObserver.observe(container);
+    }
+
+    return () => {
+      resizeObserver?.disconnect();
+      gui.dispose();
+      engine.dispose();
+      engineRef.current = null;
+      sceneRef.current = null;
+      guiRef.current = null;
+    };
+  }, []);
+
+  // Rebuild meshes when data/view changes
+  useEffect(() => {
+    const scene = sceneRef.current;
+    const gui = guiRef.current;
+    if (!scene || !gui) return;
+
+    // Dispose old graph meshes
+    const toDispose: AbstractMesh[] = [];
+    for (const mesh of scene.meshes) {
+      if (mesh.metadata?.[GRAPH_TAG]) {
+        toDispose.push(mesh);
+      }
+    }
+    for (const mesh of toDispose) {
+      mesh.dispose();
+    }
+
+    // Remove old labels
+    const controls = gui.getDescendants();
+    for (const ctrl of controls) {
+      if (ctrl.name?.startsWith("label_")) {
+        ctrl.dispose();
+      }
+    }
+
+    const { nodes, links } = buildGraph(
+      organizations,
+      agents,
+      tasks,
+      peers,
+      activeView,
+    );
+
+    if (nodes.length === 0) return;
+
+    const positions = layout3d(nodes, links);
+    const posMap = new Map(positions.map((p) => [p.id, p]));
+
+    // Create node spheres
+    for (const node of nodes) {
+      const pos = posMap.get(node.id);
+      if (!pos) continue;
+
+      const radius = nodeRadius(node.type, node.data);
+      const sphere = MeshBuilder.CreateSphere(
+        `node_${node.id}`,
+        { diameter: radius * 2, segments: 12 },
+        scene,
+      );
+      sphere.position = new Vector3(pos.x, pos.y, pos.z);
+      sphere.metadata = { [GRAPH_TAG]: true, graphNode: node };
+
+      const mat = new StandardMaterial(`mat_${node.id}`, scene);
+      const color = hexToColor3(NODE_COLORS[node.type] ?? "#6b7280");
+      mat.diffuseColor = color;
+      mat.emissiveColor = color.scale(0.4);
+      mat.specularColor = new Color3(0.2, 0.2, 0.2);
+      sphere.material = mat;
+
+      // Click handling
+      sphere.actionManager = new ActionManager(scene);
+      sphere.actionManager.registerAction(
+        new ExecuteCodeAction(ActionManager.OnPickTrigger, () => {
+          onNodeClick(node);
+        }),
+      );
+
+      // Hover cursor
+      sphere.actionManager.registerAction(
+        new ExecuteCodeAction(ActionManager.OnPointerOverTrigger, () => {
+          if (scene.getEngine().getRenderingCanvas()) {
+            scene.getEngine().getRenderingCanvas()!.style.cursor = "pointer";
+          }
+        }),
+      );
+      sphere.actionManager.registerAction(
+        new ExecuteCodeAction(ActionManager.OnPointerOutTrigger, () => {
+          if (scene.getEngine().getRenderingCanvas()) {
+            scene.getEngine().getRenderingCanvas()!.style.cursor = "default";
+          }
+        }),
+      );
+
+      // Label
+      const label = new TextBlock(`label_${node.id}`);
+      const maxLen = node.type === "org" || node.type === "suborg" ? 24 : 16;
+      label.text =
+        node.label.length > maxLen
+          ? node.label.slice(0, maxLen - 2) + "…"
+          : node.label;
+      label.color = "#d1d5db";
+      label.fontSize = 12;
+      label.outlineWidth = 2;
+      label.outlineColor = "#030712";
+      label.linkOffsetY = -radius * 80 - 20;
+      gui.addControl(label);
+      label.linkWithMesh(sphere);
+    }
+
+    // Create link lines
+    for (const link of links) {
+      const sPos = posMap.get(link.source as string);
+      const tPos = posMap.get(link.target as string);
+      if (!sPos || !tPos) continue;
+
+      const line = MeshBuilder.CreateLines(
+        `link_${link.source}_${link.target}`,
+        {
+          points: [
+            new Vector3(sPos.x, sPos.y, sPos.z),
+            new Vector3(tPos.x, tPos.y, tPos.z),
+          ],
+        },
+        scene,
+      );
+      line.color = new Color3(0.3, 0.35, 0.45);
+      line.alpha = 0.5;
+      line.metadata = { [GRAPH_TAG]: true };
+    }
+
+    // Auto-fit camera
+    const camera = scene.activeCamera as ArcRotateCamera | null;
+    if (camera && positions.length > 0) {
+      let cx = 0,
+        cy = 0,
+        cz = 0;
+      for (const p of positions) {
+        cx += p.x;
+        cy += p.y;
+        cz += p.z;
+      }
+      cx /= positions.length;
+      cy /= positions.length;
+      cz /= positions.length;
+
+      let maxDist = 0;
+      for (const p of positions) {
+        const d = Math.sqrt(
+          (p.x - cx) ** 2 + (p.y - cy) ** 2 + (p.z - cz) ** 2,
+        );
+        if (d > maxDist) maxDist = d;
+      }
+
+      camera.target = new Vector3(cx, cy, cz);
+      camera.radius = Math.max(maxDist * 2.5, 8);
+    }
+  }, [organizations, agents, tasks, peers, activeView, onNodeClick]);
+
+  return (
+    <div className="w-full h-full min-h-[400px]">
+      <canvas
+        ref={canvasRef}
+        className="w-full h-full outline-none"
+        style={{ background: "transparent" }}
+      />
+    </div>
+  );
+}

--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -59,6 +59,8 @@ function getDisplayName(item: DetailItem): string {
   if (typeof d.name === "string" && d.name) return d.name;
   if (typeof d.title === "string" && d.title) return d.title;
   if (typeof d.node_id === "string" && d.node_id) return d.node_id;
+  if (typeof d.profile_name === "string" && d.profile_name)
+    return d.profile_name;
   if (typeof d.agent === "string" && d.agent)
     return truncateId(d.agent as string, 4);
   return truncateId(String(d.id ?? ""));
@@ -171,6 +173,9 @@ function OrgDetail({ org }: { org: Organization }) {
 function AgentDetail({ agent }: { agent: AgentCertificate }) {
   return (
     <>
+      {agent.profile_name && (
+        <Field label="Profile Name" value={agent.profile_name} />
+      )}
       <Field label="Agent Address" value={<IdLink id={agent.agent} />} />
       <Field
         label="Status"

--- a/src/components/ForceGraph.tsx
+++ b/src/components/ForceGraph.tsx
@@ -8,7 +8,8 @@ import type {
   GraphNode,
   GraphLink,
 } from "../sui/types.ts";
-import { NODE_COLORS, truncateId } from "./utils.ts";
+import { NODE_COLORS } from "./utils.ts";
+import { buildGraph } from "./graphUtils.ts";
 
 interface Props {
   organizations: Organization[];
@@ -17,99 +18,6 @@ interface Props {
   peers: PeerNode[];
   activeView: "org" | "tasks" | "peers";
   onNodeClick: (node: GraphNode) => void;
-}
-
-function buildGraph(
-  orgs: Organization[],
-  agents: AgentCertificate[],
-  tasks: Task[],
-  peers: PeerNode[],
-  view: "org" | "tasks" | "peers",
-): { nodes: GraphNode[]; links: GraphLink[] } {
-  const nodes: GraphNode[] = [];
-  const links: GraphLink[] = [];
-
-  if (view === "org" || view === "tasks") {
-    for (const org of orgs) {
-      const isSubOrg = org.depth > 0;
-      const displayName = org.name?.replace(/-\d{13}$/, "") || truncateId(org.id);
-      const agentSuffix = org.agent_count > 0 ? ` (${org.agent_count}A)` : "";
-      nodes.push({
-        id: org.id,
-        label: displayName + agentSuffix,
-        type: isSubOrg ? "suborg" : "org",
-        data: org,
-      });
-      if (org.parent_org) {
-        links.push({ source: org.parent_org, target: org.id, type: "parent" });
-      }
-    }
-
-    for (const a of agents) {
-      nodes.push({
-        id: a.id,
-        label: truncateId(a.agent, 4),
-        type: "agent",
-        status: a.status,
-        data: a,
-      });
-      if (a.org_id) {
-        links.push({ source: a.org_id, target: a.id, type: "contains" });
-      }
-    }
-
-    if (view === "tasks") {
-      for (const t of tasks) {
-        nodes.push({
-          id: t.id,
-          label: t.title || truncateId(t.id),
-          type: "task",
-          status: t.status,
-          data: t,
-        });
-        if (t.assignee) {
-          const cert = agents.find(
-            (a) => a.agent === t.assignee && a.org_id === t.org_id,
-          );
-          if (cert) {
-            links.push({ source: cert.id, target: t.id, type: "assigned" });
-          } else if (t.org_id) {
-            links.push({ source: t.org_id, target: t.id, type: "contains" });
-          }
-        } else if (t.org_id) {
-          links.push({ source: t.org_id, target: t.id, type: "contains" });
-        }
-      }
-    }
-  }
-
-  if (view === "peers") {
-    for (const p of peers) {
-      nodes.push({
-        id: p.id,
-        label: p.node_id || truncateId(p.id),
-        type: "peer",
-        status: p.status,
-        data: p,
-      });
-    }
-    for (let i = 0; i < peers.length; i++) {
-      for (let j = i + 1; j < peers.length; j++) {
-        links.push({
-          source: peers[i].id,
-          target: peers[j].id,
-          type: "peer-link",
-        });
-      }
-    }
-  }
-
-  const nodeIds = new Set(nodes.map((n) => n.id));
-  const validLinks = links.filter(
-    (l) => nodeIds.has(l.source as string) && nodeIds.has(l.target as string),
-  );
-
-  return { nodes, links: validLinks };
 }
 
 export default function ForceGraph({

--- a/src/components/graphUtils.ts
+++ b/src/components/graphUtils.ts
@@ -1,0 +1,102 @@
+import type {
+  Organization,
+  AgentCertificate,
+  Task,
+  PeerNode,
+  GraphNode,
+  GraphLink,
+} from "../sui/types.ts";
+import { truncateId } from "./utils.ts";
+
+export function buildGraph(
+  orgs: Organization[],
+  agents: AgentCertificate[],
+  tasks: Task[],
+  peers: PeerNode[],
+  view: "org" | "tasks" | "peers",
+): { nodes: GraphNode[]; links: GraphLink[] } {
+  const nodes: GraphNode[] = [];
+  const links: GraphLink[] = [];
+
+  if (view === "org" || view === "tasks") {
+    for (const org of orgs) {
+      const isSubOrg = org.depth > 0;
+      const displayName = org.name?.replace(/-\d{13}$/, "") || truncateId(org.id);
+      const agentSuffix = org.agent_count > 0 ? ` (${org.agent_count}A)` : "";
+      nodes.push({
+        id: org.id,
+        label: displayName + agentSuffix,
+        type: isSubOrg ? "suborg" : "org",
+        data: org,
+      });
+      if (org.parent_org) {
+        links.push({ source: org.parent_org, target: org.id, type: "parent" });
+      }
+    }
+
+    for (const a of agents) {
+      nodes.push({
+        id: a.id,
+        label: a.profile_name || truncateId(a.agent, 4),
+        type: "agent",
+        status: a.status,
+        data: a,
+      });
+      if (a.org_id) {
+        links.push({ source: a.org_id, target: a.id, type: "contains" });
+      }
+    }
+
+    if (view === "tasks") {
+      for (const t of tasks) {
+        nodes.push({
+          id: t.id,
+          label: t.title || truncateId(t.id),
+          type: "task",
+          status: t.status,
+          data: t,
+        });
+        if (t.assignee) {
+          const cert = agents.find(
+            (a) => a.agent === t.assignee && a.org_id === t.org_id,
+          );
+          if (cert) {
+            links.push({ source: cert.id, target: t.id, type: "assigned" });
+          } else if (t.org_id) {
+            links.push({ source: t.org_id, target: t.id, type: "contains" });
+          }
+        } else if (t.org_id) {
+          links.push({ source: t.org_id, target: t.id, type: "contains" });
+        }
+      }
+    }
+  }
+
+  if (view === "peers") {
+    for (const p of peers) {
+      nodes.push({
+        id: p.id,
+        label: p.node_id || truncateId(p.id),
+        type: "peer",
+        status: p.status,
+        data: p,
+      });
+    }
+    for (let i = 0; i < peers.length; i++) {
+      for (let j = i + 1; j < peers.length; j++) {
+        links.push({
+          source: peers[i].id,
+          target: peers[j].id,
+          type: "peer-link",
+        });
+      }
+    }
+  }
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const validLinks = links.filter(
+    (l) => nodeIds.has(l.source as string) && nodeIds.has(l.target as string),
+  );
+
+  return { nodes, links: validLinks };
+}

--- a/src/components/layout3d.ts
+++ b/src/components/layout3d.ts
@@ -1,0 +1,103 @@
+import type { GraphNode, GraphLink } from "../sui/types.ts";
+
+export interface LayoutNode {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * Simple 3D force-directed layout using Coulomb repulsion + spring attraction.
+ * O(n²) per iteration — fine for <50 nodes.
+ */
+export function layout3d(
+  nodes: GraphNode[],
+  links: GraphLink[],
+  iterations = 300,
+): LayoutNode[] {
+  const positions: LayoutNode[] = nodes.map((n) => ({
+    id: n.id,
+    x: (Math.random() - 0.5) * 10,
+    y: (Math.random() - 0.5) * 10,
+    z: (Math.random() - 0.5) * 10,
+  }));
+
+  const idxMap = new Map<string, number>();
+  positions.forEach((p, i) => idxMap.set(p.id, i));
+
+  const repulsion = 50;
+  const springK = 0.02;
+  const springLen = 3;
+  const damping = 0.9;
+  const dt = 0.3;
+
+  const vx = new Float64Array(positions.length);
+  const vy = new Float64Array(positions.length);
+  const vz = new Float64Array(positions.length);
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const temp = 1 - iter / iterations;
+
+    // Coulomb repulsion between all pairs
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        let dx = positions[i].x - positions[j].x;
+        let dy = positions[i].y - positions[j].y;
+        let dz = positions[i].z - positions[j].z;
+        let dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (dist < 0.1) dist = 0.1;
+
+        const force = (repulsion * temp) / (dist * dist);
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        const fz = (dz / dist) * force;
+
+        vx[i] += fx;
+        vy[i] += fy;
+        vz[i] += fz;
+        vx[j] -= fx;
+        vy[j] -= fy;
+        vz[j] -= fz;
+      }
+    }
+
+    // Spring attraction along edges
+    for (const link of links) {
+      const si = idxMap.get(link.source as string);
+      const ti = idxMap.get(link.target as string);
+      if (si === undefined || ti === undefined) continue;
+
+      let dx = positions[ti].x - positions[si].x;
+      let dy = positions[ti].y - positions[si].y;
+      let dz = positions[ti].z - positions[si].z;
+      let dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      if (dist < 0.01) dist = 0.01;
+
+      const displacement = dist - springLen;
+      const force = springK * displacement;
+      const fx = (dx / dist) * force;
+      const fy = (dy / dist) * force;
+      const fz = (dz / dist) * force;
+
+      vx[si] += fx;
+      vy[si] += fy;
+      vz[si] += fz;
+      vx[ti] -= fx;
+      vy[ti] -= fy;
+      vz[ti] -= fz;
+    }
+
+    // Apply velocity + damping
+    for (let i = 0; i < positions.length; i++) {
+      vx[i] *= damping;
+      vy[i] *= damping;
+      vz[i] *= damping;
+      positions[i].x += vx[i] * dt;
+      positions[i].y += vy[i] * dt;
+      positions[i].z += vz[i] * dt;
+    }
+  }
+
+  return positions;
+}

--- a/src/sui/queries.ts
+++ b/src/sui/queries.ts
@@ -221,6 +221,57 @@ function parsePeerNode(
 
 // ── Public query API ───────────────────────────────────────────────
 
+/**
+ * Fetch AgentProfile DOFs from an Organization object.
+ * Returns a map of agent address → { name, avatar_url }.
+ */
+async function fetchAgentProfiles(
+  orgId: string,
+): Promise<Map<string, { name: string; avatar_url: string }>> {
+  const profileMap = new Map<string, { name: string; avatar_url: string }>();
+
+  try {
+    let cursor: string | null = null;
+    let hasNext = true;
+
+    while (hasNext) {
+      const page = await client.getDynamicFields({
+        parentId: orgId,
+        cursor: cursor ?? undefined,
+        limit: 50,
+      });
+
+      for (const entry of page.data) {
+        // Filter only ProfileKey dynamic object fields
+        if (
+          entry.type === "DynamicObject" &&
+          typeof entry.name.type === "string" &&
+          entry.name.type.includes("::profile::ProfileKey")
+        ) {
+          const profileResp = await getObject(entry.objectId);
+          const fields = extractFields(profileResp);
+          if (!fields) continue;
+
+          const agentAddr = getString(fields, "agent");
+          const name = getString(fields, "name");
+          const avatarUrl = getString(fields, "avatar_url");
+
+          if (agentAddr) {
+            profileMap.set(agentAddr, { name, avatar_url: avatarUrl });
+          }
+        }
+      }
+
+      cursor = page.nextCursor ?? null;
+      hasNext = page.hasNextPage;
+    }
+  } catch (error) {
+    console.error(`Failed to fetch AgentProfiles for org ${orgId}:`, error);
+  }
+
+  return profileMap;
+}
+
 async function fetchOrgIdsFromRegistry(): Promise<string[]> {
   const resp = await getObject(SUI_CONFIG.registry);
   const fields = extractFields(resp);
@@ -268,6 +319,7 @@ async function fetchOrganizationsWithTables(
 
 async function fetchAgentCertificates(
   agentAddresses: string[],
+  profilesByAgent: Map<string, { name: string; avatar_url: string }>,
 ): Promise<AgentCertificate[]> {
   const certs: AgentCertificate[] = [];
   const seen = new Set<string>();
@@ -293,7 +345,13 @@ async function fetchAgentCertificates(
         seen.add(id);
         const fields = extractFields(item);
         if (!fields) continue;
-        certs.push(parseAgentCertificate(id, fields));
+        const cert = parseAgentCertificate(id, fields);
+        const profile = profilesByAgent.get(cert.agent);
+        if (profile) {
+          cert.profile_name = profile.name;
+          cert.profile_avatar_url = profile.avatar_url || undefined;
+        }
+        certs.push(cert);
       }
 
       cursor = page.nextCursor ?? null;
@@ -350,14 +408,23 @@ export async function fetchAllData() {
 
   const allAgentAddresses = new Set<string>();
   const allTaskIds = new Set<string>();
+  const allProfiles = new Map<string, { name: string; avatar_url: string }>();
 
   for (const org of organizations) {
     for (const addr of org.agent_addresses) allAgentAddresses.add(addr);
     for (const tid of org.task_ids) allTaskIds.add(tid);
   }
 
+  // Fetch profiles from all orgs in parallel
+  const profileResults = await Promise.all(
+    organizations.map((org) => fetchAgentProfiles(org.id)),
+  );
+  for (const profileMap of profileResults) {
+    profileMap.forEach((profile, addr) => allProfiles.set(addr, profile));
+  }
+
   const [agents, tasks, peers] = await Promise.all([
-    fetchAgentCertificates([...allAgentAddresses]),
+    fetchAgentCertificates([...allAgentAddresses], allProfiles),
     fetchTasks([...allTaskIds]),
     fetchPeerNodes(),
   ]);

--- a/src/sui/types.ts
+++ b/src/sui/types.ts
@@ -37,6 +37,9 @@ export interface AgentCertificate {
   reputation_score: number;
   status: AgentStatus;
   tasks_completed: number;
+  /** From AgentProfile DOF on Organization */
+  profile_name?: string;
+  profile_avatar_url?: string;
 }
 
 /** Agent status u8: 0 = active, 1 = idle, 2 = suspended, 3 = offline */


### PR DESCRIPTION
## Summary
- Add BabylonJS 3D graph view with 2D/3D toggle button (default 3D)
- Fetch AgentProfile DOF from Organization objects on-chain
- Display agent profile names instead of hex addresses in graph and detail panel

## Changes
- **BabylonGraph.tsx**: Full 3D visualization with ArcRotateCamera, sphere nodes, line links, billboard labels
- **graphUtils.ts**: Shared `buildGraph()` extracted from ForceGraph
- **layout3d.ts**: 3D force-directed layout engine (Coulomb repulsion + spring attraction)
- **queries.ts**: `fetchAgentProfiles()` reads ProfileKey DOFs from Organization
- **types.ts**: `profile_name` and `profile_avatar_url` on AgentCertificate
- **DetailPanel.tsx**: Shows Profile Name field in agent details
- **App.tsx**: 2D/3D toggle button, default 3D view

## Test plan
- [ ] Verify 3D view renders with BabylonJS (org/agent/task nodes visible)
- [ ] Verify 2D/3D toggle works, preserves data state
- [ ] Verify SuLabs agents show names (OpenClaw, RoseX, Sentinel) instead of hex
- [ ] Verify agent detail panel shows Profile Name field
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)